### PR TITLE
Expands error cases

### DIFF
--- a/aubo_controller/package.xml
+++ b/aubo_controller/package.xml
@@ -29,6 +29,7 @@
   <build_depend>interactive_markers</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>geometric_shapes</build_depend>
+  <build_depend>aubo_msgs</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/aubo_controller/package.xml
+++ b/aubo_controller/package.xml
@@ -49,4 +49,6 @@
   <run_depend>moveit_ros_perception</run_depend>
   <run_depend>interactive_markers</run_depend>
 
+  <build_depend>industrial_core</build_depend>
+
 </package>

--- a/aubo_demo/package.xml
+++ b/aubo_demo/package.xml
@@ -18,6 +18,8 @@
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  
+  <depend>moveit_visual_tools</depend>
 
   <export>
   </export>

--- a/aubo_description/urdf/aubo_i5.urdf
+++ b/aubo_description/urdf/aubo_i5.urdf
@@ -48,7 +48,7 @@
   </link>
 
   <joint name="shoulder_joint" type="revolute">
-    <origin xyz="0 0 0.122" rpy="0 0 3.1416" />
+    <origin xyz="0 0 0.0985" rpy="0 0 3.1416" /> <!-- 0.122 - 0.0235 -->
     <parent link="base_link" />
     <child link="shoulder_Link" />
     <axis xyz="0 0 1" />

--- a/aubo_description/urdf/aubo_i5.urdf.xacro
+++ b/aubo_description/urdf/aubo_i5.urdf.xacro
@@ -56,7 +56,7 @@
   </link>
 
   <joint name="shoulder_joint" type="revolute">
-    <origin xyz="0 0 0.122" rpy="0 0 3.1416" />
+    <origin xyz="0 0 $(0.122 - 0.0235)" rpy="0 0 3.1416" />
     <parent link="base_link" />
     <child link="shoulder_Link" />
     <axis xyz="0 0 1" />

--- a/aubo_driver/src/aubo_driver.cpp
+++ b/aubo_driver/src/aubo_driver.cpp
@@ -119,9 +119,20 @@ void AuboDriver::timerCallback(const ros::TimerEvent& e)
                 robot_status_.mode.val            = (int8)rs.robot_diagnosis_info_.orpeStatus;
                 robot_status_.e_stopped.val       = (int8)(rs.robot_diagnosis_info_.softEmergency || emergency_stopped_);
                 robot_status_.drives_powered.val  = (int8)rs.robot_diagnosis_info_.armPowerStatus;
-                robot_status_.motion_possible.val = (int)(!start_move_);
                 robot_status_.in_motion.val       = (int)start_move_;
-                robot_status_.in_error.val        = (int)protective_stopped_;   //used for protective stop.
+                robot_status_.in_error.val        = 
+                    (int)(protective_stopped_ ||
+                    rs.robot_diagnosis_info_.softEmergency ||
+                    rs.robot_diagnosis_info_.robotCollision ||
+                    rs.robot_diagnosis_info_.staticCollisionDetect ||
+                    rs.robot_diagnosis_info_.remoteEmergency
+                    );
+                robot_status_.motion_possible.val = 
+                    (int)(
+                        !start_move_ && 
+                        robot_status_.drives_powered.val &&
+                        !rs.robot_diagnosis_info_.brakeStuats &&
+                        !robot_status_.in_error.val);
                 robot_status_.error_code          = (int32)rs.robot_diagnosis_info_.singularityOverSpeedAlarm;
             }
         }

--- a/aubo_planner/package.xml
+++ b/aubo_planner/package.xml
@@ -29,6 +29,7 @@
   <build_depend>interactive_markers</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>geometric_shapes</build_depend>
+  <build_depend>aubo_msgs</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/aubo_robot/package.xml
+++ b/aubo_robot/package.xml
@@ -12,17 +12,10 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <run_depend>aubo_panel</run_depend>
   <run_depend>aubo_i5_moveit_config</run_depend>
   <run_depend>aubo_description</run_depend>
   <run_depend>aubo_msgs</run_depend>
-  <run_depend>aubo_control</run_depend>
   <run_depend>aubo_driver</run_depend>
-  <run_depend>aubo_new_driver</run_depend>
-  <run_depend>aubo_gazebo</run_depend>
-  <run_depend>aubo_kinematics</run_depend>
-  <run_depend>aubo_trajectory</run_depend>
-  <run_depend>aubo_trajectory_filters</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Hi,

I have been playing with the AUBO ROS driver and noticed that the `robot_status` topic does not change according to the status of the robot. 

So I added a few cases when the `in_motion` and `in_error` flags set for better error handling.